### PR TITLE
fix: eslint-config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,17 +1,17 @@
 /**
  * Copyright 2023 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 module.exports = {
@@ -25,11 +25,32 @@ module.exports = {
 
   overrides: [
     {
-      files: ['**/*.ts'],
+      files: ['./src/**/*.ts'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         sourceType: 'module',
         tsconfigRootDir: __dirname,
+        project: ['./tsconfig.json']
+      },
+      plugins: ['@typescript-eslint'],
+      extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking'
+      ],
+      rules: {
+        '@typescript-eslint/no-inferrable-types': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/require-await': 'off',
+        'prefer-const': ['error', {destructuring: 'all'}]
+      }
+    },
+    {
+      files: ['./examples/playground/src/**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        sourceType: 'module',
+        tsconfigRootDir: `${__dirname}/examples/playground/`,
         project: ['./tsconfig.json']
       },
       plugins: ['@typescript-eslint'],


### PR DESCRIPTION
in my local installation the eslint-configuration was causing a ton of errors since it couldn't properly handle the ts-files in the examples/playground folder.

This adds a seperate configuration for those files so tests pass without a problem.