### PR TITLE
chore: fix build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Test
         run: |
           npm i
-          npm run test:jest
+          npm run test
       - name: Release
         uses: cycjimmy/semantic-release-action@v3
         with:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "test": "run-s test:*",
+     "prepack": "npm run build",
     "test:tsc": "tsc",
     "test:prettier": "prettier -c ./src",
     "test:eslint": "eslint './src/**/*ts' './examples/playground/src/*.ts'",


### PR DESCRIPTION
As noted in #4, the build task wasn't run when publishing the package to npm. To fix that, we're adding the build-task to the prepack hook, so it will run before a package is created to be uploaded to npm.

Also, since #2 and #3 should fix the tsc, eslint and prettier tests, this also reenables the full test-suite for the release task.

Fixes #4 🦕
