### PR TITLE
fix: npm run test required depdendencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
             ${{ runner.os }}-node-
       - name: Test
         run: |
-          npm i
-          npm run test:jest
+          npm ci
+          npm run test
       - name: Release
         uses: cycjimmy/semantic-release-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
@@ -25,5 +25,5 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm i
-      - run: npm run test:jest
+      - run: npm ci
+      - run: npm run test

--- a/examples/playground/package-lock.json
+++ b/examples/playground/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@googlemaps/marker__playground",
       "version": "1.3.0",
       "dependencies": {
-        "monaco-editor": "^0.41.0"
+        "monaco-editor": "^0.40.0"
       },
       "devDependencies": {
         "@types/google.maps": "^3.50.5",
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
-      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA=="
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.40.0.tgz",
+      "integrity": "sha512-1wymccLEuFSMBvCk/jT1YDW/GuxMLYwnFwF9CDyYCxoTw2Pt379J3FUhwy9c43j51JdcxVPjwk0jm0EVDsBS2g=="
     },
     "node_modules/mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clean": "rm -rf ./dist",
     "test": "run-s test:*",
     "prepack": "npm run build",
+    "pretest": "cd ./examples/playground && ( [ -d ./node_modules ] || npm install )",
     "test:tsc": "tsc",
     "test:prettier": "prettier -c ./src",
     "test:eslint": "eslint './src/**/*ts' './examples/playground/src/*.ts'",


### PR DESCRIPTION
The depdendencies for the playground in `examples/playground/node_modules` have to be installed for the tests to run successfully, since eslint runs for both projects in one go.

This patch adds a pretest hook to make sure the depdendencies are installed before running the tests.