### PR TITLE
feat: examples updated and cleaned up

### DIFF
--- a/examples/html/README.md
+++ b/examples/html/README.md
@@ -1,0 +1,22 @@
+# Advanced Markers Utils – HTML Examples
+
+This directory contains examples for the different ways to use
+`@googlemaps/adv-markers-utils` in a plain html file without needing a
+bundler or similar.
+
+- **`esm.html`** shows how to load the library from a CDN
+  ([unpkg.com](https://unpkg.com) in this example) as a native ES module.
+- **`importmap.html`** is similar, but it uses [importmaps][mdn_importmap]
+  to load the library.
+- **`umd.html`** uses the UMD build of the library for older browsers.
+
+To run these examples, you only need an HTTP-Server and [a Google Maps API Key][gmp_apikey].
+If you have node.js installed, you can start a server by running the command
+
+    npx http-server
+
+in this directory and opening the URL shown in your browser (typically http://localhost:8080).
+The site will then ask for the Google Maps API Key to use and show the map with the marker.
+
+[mdn_importmap]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
+[gmp_apikey]: https://developers.google.com/maps/documentation/javascript/get-api-key#create-api-keys

--- a/examples/html/esm.html
+++ b/examples/html/esm.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
  Copyright 2023 Google LLC
 
@@ -22,7 +22,7 @@
       name="viewport"
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     />
-    <title>Map / Marker example using importmaps</title>
+    <title>Map / Marker example using native ES modules</title>
     <style>
       body {
         margin: 0;
@@ -64,11 +64,10 @@
     <div id="map"></div>
 
     <script type="module">
-      import {Marker} from 'https://storage.ubidev.net/marker-api-playground/lib/index.module.js';
+      import {Marker} from 'https://unpkg.com/@googlemaps/adv-markers-utils/dist/index.module.js';
 
       async function main() {
         const {Map} = await google.maps.importLibrary('maps');
-
         await google.maps.importLibrary('marker');
 
         const map = new Map(document.querySelector('#map'), {

--- a/examples/html/importmap.html
+++ b/examples/html/importmap.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
  Copyright 2023 Google LLC
 
@@ -41,9 +41,9 @@
     <script type="importmap">
       {
         "imports": {
-          "@googlemaps/marker": "https://storage.ubidev.net/marker-api-playground/lib/index.module.js",
-          "@googlemaps/marker/icons": "https://storage.ubidev.net/marker-api-playground/lib/icons.module.js",
-          "@googlemaps/marker/places": "https://storage.ubidev.net/marker-api-playground/lib/places.module.js"
+          "@googlemaps/marker": "https://unpkg.com/@googlemaps/adv-markers-utils/dist/index.module.js",
+          "@googlemaps/marker/icons": "https://unpkg.com/@googlemaps/adv-markers-utils/dist/icons.module.js",
+          "@googlemaps/marker/places": "https://unpkg.com/@googlemaps/adv-markers-utils/dist/places.module.js"
         }
       }
     </script>

--- a/examples/html/umd.html
+++ b/examples/html/umd.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
  Copyright 2023 Google LLC
 
@@ -59,17 +59,17 @@
         v: "beta"
       });
     </script>
-    <script src="https://storage.ubidev.net/marker-api-playground/lib/index.umd.js"></script>
+    <script src="https://unpkg.com/@googlemaps/adv-markers-utils/dist/index.umd.js"></script>
   </head>
   <body>
     <div id="map"></div>
 
-    <script type="module">
+    <script>
       async function main() {
         const {Map} = await google.maps.importLibrary('maps');
         await google.maps.importLibrary('marker');
 
-        const {Marker} = google.maps.plugins.marker;
+        const {Marker} = google.maps.plugins.advMarkersUtils;
 
         const map = new Map(document.querySelector('#map'), {
           mapId: 'bf51a910020fa25a',

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,25 +1,24 @@
-# Marker API Playground
+# Advanced Markers Utils – Marker Playground
 
-This directory is the testing ground and development-environment for
-the marker API.
+This directory contains a simple playground application for the marker API.
 
 ## Get Started
 
-1. Change into the playground-folder and install dependencies:
+1.  Change into the playground-folder and install dependencies:
 
         cd examples/playground
         npm install
 
-2. [Create an API-key][gmp_create_apikey] for the Google Maps API.
-3. create a file `.env` with the API key in the following format:
+2.  [Create an API-key][gmp_create_apikey] for the Google Maps API.
+3.  create a file `.env` with the API key in the following format:
 
-       GOOGLE_MAPS_API_KEY="<INSERT API KEY HERE>"
+    GOOGLE_MAPS_API_KEY="<INSERT API KEY HERE>"
 
-4. start the development server:
+4.  start the development server:
 
-       npm start
+    npm start
 
-5. open http://localhost:5173 in your browser
+5.  open http://localhost:5173 in your browser
 
 [gmp_create_apikey]: https://developers.google.com/maps/documentation/embed/get-api-key#create-api-keys
 
@@ -31,14 +30,14 @@ marker-API can be written and executed to get a feel for the api and test
 different usage-scenarios in a fast way. The contents of the editor can be
 serialized into the URL for sharing.
 
-Compiling the typescript happens in a worker via the typescript-support
+Compiling the typescript from the editor happens in a worker via the typescript-support
 already built into the monaco-editor. For execution, a wrapper emulates the
-common.js environment to allow importing a predefined set of modules. Other
+common.js environment to allow importing a predefined set of modules. External
 modules can only be imported using async imports from urls.
 
 ## Code Organization
 
-- `/`: contains `index.html`, `examples.html` and configuration-files
+- `/`: contains `index.html` and configuration-files
 - `/src`: the typescript source-root. The application entrypoint is in `main.ts`
 - `/src/code-samples`: contains the source-files for all examples. The
   typescript files here should all follow the conventions for examples below.
@@ -49,35 +48,22 @@ modules can only be imported using async imports from urls.
 - each example should demonstrate a single aspect of the library in a
   concise way - try to remove 'noise', that is code for unrelated aspects,
   as much as possible, embrace duplication
-- the first line of the example has to contain a comment in the form:
-  `// title: This describes what it does` - this comment will be the text
-  shown in the example-index
 - the example must import components from the marker-library using regular
-  imports (e.g. `import {Marker} from '@ubilabs/google-maps-marker';`).
+  imports (e.g. `import {Marker} from '@googlemaps/adv-markers-utils';`).
 - there has to be a default export, which will be called with the
   map-instance as parameter when the script is run
 - When any changes are done in the browser environment (event-listeners,
   timeouts, intervals, ...), the exported function has to return a cleanup
-  function removing all those. This doesn't apply for created markers and
-  marker-collections, those are automatically removed from the map when a
-  new version of the script is executed.
+  function removing all those. For convenience, this does not apply for
+  created markers and marker-collections, those are automatically removed
+  from the map when a new version of the script is executed.
 
 ## scripts, npm-tasks and deployment
 
-The published version of this is hosted on google cloud storage and available
-here: https://storage.ubidev.net/marker-api-playground
-
-Be aware that people outside ubilabs have access to the deployed version
-and while we can actively develop and publish new versions, the deployed
-version should always be manually checked after a deployment.
-
 The following supporting scripts and tasks are available:
 
-- `npm start`: starts the vite dev-server (this will also run the `build:dts`
-  and `build:examples` tasks)
+- `npm start`: starts the vite dev-server
 - `npm run build`: runs all `build:*` tasks followed by `vite build` to
   generate the full application in `./dist`
 - `npm run preview`: runs the full build and starts the vite preview server
   to review everything as if it were in production
-- `npm run deploy`: deploys the application to google cloud storage bucket
-  `gs://storage.ubidev.net/marker-api-playground`

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,7 +6,6 @@
     "build:lib": "cd ../.. && npm run build",
     "build": "run-p build:* && vite build",
     "preview": "run-s build && vite preview",
-    "deploy": "run-s build && gsutil -m rsync -rc ./dist/ gs://geo-devrel-public-buckets/adv-markers-util-playground/",
     "serve": "vite",
     "watch:library": "cd ../.. && npm run watch"
   },

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,13 @@
+# Advanced Markers Utils – TypeScript / vite Example
+
+This directory contains a minimal example application built with typescript/vite.
+
+To run these examples, you need [a Google Maps API Key][gmp_apikey]. change into the `./examples/typescript`-directory and run
+
+    npm install
+    npm start
+
+This will start the vite development-server, and print the URL to the console (typically http://localhost:5173/).
+When opening the site, it will ask for the Google Maps API Key.
+
+[gmp_apikey]: https://developers.google.com/maps/documentation/javascript/get-api-key#create-api-keys

--- a/examples/typescript/env.d.ts
+++ b/examples/typescript/env.d.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// <reference types="vite/client" />
+interface ImportMetaEnv {
+  readonly VITE_GOOGLEMAPS_API_KEY: string;
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>@googlemaps/marker - vite / typescript example</title>
+    <style>
+      body {
+        margin: 0;
+      }
+      #map {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/examples/typescript/main.ts
+++ b/examples/typescript/main.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Loader} from '@googlemaps/js-api-loader';
+import {Marker} from '@googlemaps/adv-markers-utils';
+
+const mapDiv = document.querySelector('#map') as HTMLElement;
+
+async function main() {
+  const apiKey = getApiKey();
+  console.log('loading maps API with key: ' + apiKey);
+
+  const loader = new Loader({apiKey});
+
+  const {Map} = await loader.importLibrary('maps');
+  await loader.importLibrary('marker');
+
+  const map = new Map(mapDiv, {
+    mapId: 'bf51a910020fa25a',
+    center: {lat: 53.55, lng: 10.01},
+    zoom: 12
+  });
+
+  const marker = new Marker();
+
+  marker.position = {lat: 53.55, lng: 10.01};
+  marker.map = map;
+}
+
+// get Google Maps API Key from url or environment
+function getApiKey() {
+  const url = new URL(location.href);
+  const apiKey =
+    url.searchParams.get('apiKey') || import.meta.env.VITE_GOOGLEMAPS_API_KEY;
+
+  if (!apiKey) {
+    const key = prompt(
+      'Please provide your Google Maps API key in the URL\n' +
+        '(using the parameter `?apiKey=YOUR_API_KEY_HERE`) or enter it here:'
+    );
+
+    if (key) {
+      url.searchParams.set('apiKey', key);
+      location.replace(url.toString());
+    }
+  }
+
+  return apiKey;
+}
+
+main().catch(err => console.error(err));

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -1,0 +1,577 @@
+{
+  "name": "typescript",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@googlemaps/adv-markers-utils": "^1.1.0",
+        "@googlemaps/js-api-loader": "^1.16.2"
+      },
+      "devDependencies": {
+        "@types/google.maps": "^3.53.6",
+        "vite": "^4.4.9"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@googlemaps/adv-markers-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@googlemaps/adv-markers-utils/-/adv-markers-utils-1.1.0.tgz",
+      "integrity": "sha512-pS97nPDtwk4wGKcG4yGYCQY17nfhTmYXiQ/96i9Q3P3WJp44VeqVv1Od65O3enO1BDeIhExwgHQkBpELidSurA=="
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.53.6",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.53.6.tgz",
+      "integrity": "sha512-zDU8c7K0YR1Ob7Wn0qCSQvICIuxilZH9KFIDHK6JO/5QzqEMv8e4+9bmyoDEktA9vPNmwP++zzg65h9y53iZ6Q==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.4.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.18.10",
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@googlemaps/adv-markers-utils": "^1.1.0",
+    "@googlemaps/js-api-loader": "^1.16.2"
+  },
+  "devDependencies": {
+    "@types/google.maps": "^3.53.6",
+    "vite": "^4.4.9"
+  }
+}

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["./**/*.ts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "baseUrl": "./"
+  }
+}


### PR DESCRIPTION
- add a new example for typescript/vite usage (can be used to test proper type exports and bundler integration)
- added / updated readme-files for all example folders
- updated html-examples to use unpkg instead of prerelease URLs
- removed prerelease stuff from playground