### PR TITLE
chore: workflow to deploy website to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,118 @@
+name: Deploy to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['main']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build_playground:
+    name: Build Playground Application
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: npm
+
+      - id: configure_pages
+        name: Setup pages
+        uses: actions/configure-pages@v3
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          cd ./examples/playground && npm ci
+
+      - name: Build playground
+        run: npm run build
+        working-directory: ./examples/playground
+        env:
+          PRODUCTION_BASEURL: ${{steps.configure_pages.outputs.base_url}}/playground
+          GOOGLE_MAPS_API_KEY: ${{secrets.GOOGLE_MAPS_API_KEY}}
+          NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: playground
+          path: ./examples/playground/dist
+
+  build_docs:
+    name: Build API Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Genrate documentation
+        run: |
+          npm run build:docs
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: ./dist/docs
+
+  build:
+    name: Combine artifacts
+    needs: [build_docs, build_playground]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download docs
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: .
+
+      - name: Download playground
+        uses: actions/download-artifact@v3
+        with:
+          name: playground
+          path: playground
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: .
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "scripts": {
     "start": "npm-run-all -p build:* -s serve",
-    "build:lib": "cd ../.. && npm run build",
+    "build:lib": "cd ../.. && ( [ -f ./dist/index.module.js ] || npm run build )",
     "build": "run-p build:* && vite build",
     "preview": "run-s build && vite preview",
     "serve": "vite",

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
   "out": "./dist/docs",
   "entryPoints": ["src/index.ts", "src/icons.ts", "src/places.ts"],
   "exclude": ["**/node_modules/**", "**/*.test.ts"],
-  "name": "@googlemaps/marker",
+  "name": "@googlemaps/adv-markers-utils",
   "excludePrivate": true,
   "excludeInternal": false
 }


### PR DESCRIPTION
Adds a workflow that builds both the API docs and the playground application and deploys them to github-pages using the new actions-based deployment method.

To make this work, Github Pages pages needs to be enabled and configured to allow deployments from actions. To do that, navigate to Settings > Code and automation > Pages, then in the section "Build and deployment" select "Github Actions" as the source. This will allow the `actions/deploy-pages` action to deploy new versions of the site.

After deployment, the documentation will be available at https://googlemaps.github.io/js-adv-markers-utils and the playground will be at https://googlemaps.github.io/js-adv-markers-utils/playground

The Google Maps API key needed for the playground application should be provided as a secret under the name `GOOGLE_MAPS_API_KEY` (the key can be limited to the referrer `https://googlemaps.github.io/js-adv-markers-utils/*`)

This has already been tested in my fork of the repository, deployed versions available at https://usefulthink.github.io/js-adv-markers-utils/ and https://usefulthink.github.io/js-adv-markers-utils/playground