### PR TITLE
chore: add test requirement to dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,7 +19,10 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
   dependabot:
+    needs: test
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     env:


### PR DESCRIPTION
Require that tests pass before dependabot can automerge PRs.
