### PR TITLE
Add types to package.json exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3878,9 +3878,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001566",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-      "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -3895,7 +3895,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -19,19 +19,28 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.modern.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.modern.js"
+      },
       "require": "./dist/index.cjs",
       "umd": "./dist/index.umd.js",
       "browser": "./dist/index.module.js"
     },
     "./icons": {
-      "import": "./dist/icons.modern.js",
+      "import": {
+        "types": "./dist/icons.d.ts",
+        "default": "./dist/icons.modern.js"
+      },
       "require": "./dist/icons.cjs",
       "umd": "./dist/icons.umd.js",
       "browser": "./dist/icons.module.js"
     },
     "./places": {
-      "import": "./dist/places.modern.js",
+      "import": {
+        "types": "./dist/places.d.ts",
+        "default": "./dist/places.modern.js"
+      },
       "require": "./dist/places.cjs",
       "umd": "./dist/places.umd.js",
       "browser": "./dist/places.module.js"


### PR DESCRIPTION
Using this package with the latest default angular tsconfig, which uses 'moduleResolution: bundler' i got this typescript error:

__Could not find a declaration file for module '@googlemaps/adv-markers-utils'_
There are types at '@googlemaps/adv-markers-utils/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports"._

Updating package.json imports format resolved this issue.

 from:

`
"import": "./dist/index.modern.js,"`

to:

`"import": {
        "types": "./dist/index.d.ts",
        "default": "./dist/index.modern.js"
      }`

 🦕
